### PR TITLE
telemetry(amazonq): use ui_click telemetry for stop code generate button instead

### DIFF
--- a/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
+++ b/packages/core/src/amazonqFeatureDev/controllers/chat/controller.ts
@@ -788,24 +788,22 @@ export class FeatureDevController {
     }
 
     private async stopResponse(message: any) {
-        await telemetry.amazonq_stopCodeGeneration.run(async (span) => {
-            span.record({ tabID: message.tabID })
-            this.messenger.sendAnswer({
-                message: i18n('AWS.amazonq.featureDev.pillText.stoppingCodeGeneration'),
-                type: 'answer-part',
-                tabID: message.tabID,
-            })
-            this.messenger.sendUpdatePlaceholder(
-                message.tabID,
-                i18n('AWS.amazonq.featureDev.pillText.stoppingCodeGeneration')
-            )
-            this.messenger.sendChatInputEnabled(message.tabID, false)
-
-            const session = await this.sessionStorage.getSession(message.tabID)
-            if (session.state?.tokenSource) {
-                session.state?.tokenSource?.cancel()
-            }
+        telemetry.ui_click.emit({ elementId: 'amazonq_stopCodeGeneration' })
+        this.messenger.sendAnswer({
+            message: i18n('AWS.amazonq.featureDev.pillText.stoppingCodeGeneration'),
+            type: 'answer-part',
+            tabID: message.tabID,
         })
+        this.messenger.sendUpdatePlaceholder(
+            message.tabID,
+            i18n('AWS.amazonq.featureDev.pillText.stoppingCodeGeneration')
+        )
+        this.messenger.sendChatInputEnabled(message.tabID, false)
+
+        const session = await this.sessionStorage.getSession(message.tabID)
+        if (session.state?.tokenSource) {
+            session.state?.tokenSource?.cancel()
+        }
     }
 
     private async tabOpened(message: any) {

--- a/packages/core/src/shared/telemetry/vscodeTelemetry.json
+++ b/packages/core/src/shared/telemetry/vscodeTelemetry.json
@@ -335,11 +335,6 @@
             "name": "amazonqMessageDisplayedMs",
             "type": "int",
             "description": "Duration between the partner teams code receiving the message and when the message was finally displayed in ms"
-        },
-        {
-            "name": "tabID",
-            "type": "string",
-            "description": "The unique identifier of a tab"
         }
     ],
     "metrics": [
@@ -1189,16 +1184,6 @@
                 {
                     "type": "proxiedSessionId",
                     "required": false
-                }
-            ]
-        },
-        {
-            "name": "amazonq_stopCodeGeneration",
-            "description": "User stopped the code generation",
-            "metadata": [
-                {
-                    "type": "tabID",
-                    "required": true
                 }
             ]
         }

--- a/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
+++ b/packages/core/src/test/amazonqFeatureDev/controllers/chat/controller.test.ts
@@ -510,16 +510,13 @@ describe('Controller', () => {
     })
 
     describe('stopResponse', () => {
-        it('should emit amazonq_stopCodeGeneration telemetry', async () => {
+        it('should emit ui_click telemetry with elementId amazonq_stopCodeGeneration', async () => {
             const getSessionStub = sinon.stub(controllerSetup.sessionStorage, 'getSession').resolves(session)
             controllerSetup.emitters.stopResponse.fire({ tabID, conversationID })
             await waitUntil(() => {
                 return Promise.resolve(getSessionStub.callCount > 0)
             }, {})
-            assertTelemetry('amazonq_stopCodeGeneration', {
-                tabID: tabID,
-                result: 'Succeeded',
-            })
+            assertTelemetry('ui_click', { elementId: 'amazonq_stopCodeGeneration' })
         })
     })
 })


### PR DESCRIPTION
## Problem & Solution
Replace the `amazonq_stopCodeGeneration` telemetry with `ui_click`

Related to this feedback: https://github.com/aws/aws-toolkit-vscode/pull/5675/files#r1812947197

---

<!--- REMINDER: Ensure that your PR meets the guidelines in CONTRIBUTING.md -->

License: I confirm that my contribution is made under the terms of the Apache 2.0 license.
